### PR TITLE
Small fix for 'date' and 'dateSent' of SmsMessage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * SmsDelivery report
 * Automatically assign contact to created SmsThread
+* Small fix for 'date' and 'dateSent' of SmsMessage
 
 ## [0.0.9] - 2018-03-15
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ For help on editing plugin code, view the [documentation](https://flutter.io/pla
 - [ ] MMS Query
 - [ ] Multi Sim Card
 - [x] Contact
+-   [x] Contact Photo (full size, thumbnail)
 
 ## Contributions
 

--- a/android/src/main/java/com/babariviere/sms/SmsQuery.java
+++ b/android/src/main/java/com/babariviere/sms/SmsQuery.java
@@ -9,6 +9,7 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.util.ArrayList;
+import java.util.Date;
 
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
@@ -96,7 +97,11 @@ class SmsQuery implements MethodCallHandler, RequestPermissionsResultListener {
       try {
         if (cursor.getColumnName(idx).equals("address") || cursor.getColumnName(idx).equals("body")) {
           res.put(cursor.getColumnName(idx), cursor.getString(idx));
-        } else {
+        }
+        else if (cursor.getColumnName(idx).equals("date") || cursor.getColumnName(idx).equals("date_sent")) {
+          res.put(cursor.getColumnName(idx), cursor.getLong(idx));
+        }
+        else {
           res.put(cursor.getColumnName(idx), cursor.getInt(idx));
         }
       } catch (JSONException e) {


### PR DESCRIPTION
- Added contact photo info in roadmap just to illustrate the functionality until the plugin full documentation releases.
- Fixed error when reading fields: 'date' and 'date_sent' of sms messages from the provider. Changed the way those fields were read, from INTEGER data type to LONG data type. Now Dart code is able to parse the date in a correct way.

Tested in Android 5.0 and 7.1.1