### PR TITLE
Feature/date unification

### DIFF
--- a/example/lib/conversation/message.dart
+++ b/example/lib/conversation/message.dart
@@ -13,18 +13,32 @@ class Message extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return sent ? _sentWidget : _receivedWidget;
+    return sent ? _buildSentWidget(context) : _buildReceivedWidget(context);
   }
 
-  Widget get _sentWidget {
+  Widget _buildSentWidget(BuildContext context) {
     return new Container(
       child: new Row(
         children: <Widget>[
           new Expanded(
             child: new Container(
-              child: new Text(
-                  message.body,
-                  textAlign: TextAlign.left,
+              child: new Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: <Widget>[
+                  new Text(message.body),
+                  new Align(
+                    child: new Padding(
+                        padding: new EdgeInsets.only(top: 5.0),
+                        child: new Text(
+                          _time.format(context),
+                          style: new TextStyle(
+                            color: Colors.grey[500]
+                          ),
+                        ),
+                    ),
+                    alignment: Alignment.centerRight,
+                  )
+                ],
               ),
               margin: new EdgeInsets.only(left: 50.0),
               padding: new EdgeInsets.all(10.0),
@@ -45,7 +59,7 @@ class Message extends StatelessWidget {
     );
   }
 
-  Widget get _receivedWidget {
+  Widget _buildReceivedWidget(BuildContext context) {
     return new Container(
       child: new Row(
         children: <Widget>[
@@ -57,9 +71,23 @@ class Message extends StatelessWidget {
           ),
           new Expanded(
             child: new Container(
-              child: new Text(
-                  message.body,
-                  textAlign: TextAlign.left,
+              child: new Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: <Widget>[
+                  new Text(message.body),
+                  new Align(
+                    child: new Padding(
+                      padding: new EdgeInsets.only(top: 5.0),
+                      child: new Text(
+                        _time.format(context),
+                        style: new TextStyle(
+                            color: Colors.grey
+                        ),
+                      ),
+                    ),
+                    alignment: Alignment.centerLeft,
+                  )
+                ],
               ),
               margin: new EdgeInsets.only(right: 50.0),
               padding: new EdgeInsets.all(10.0),
@@ -70,7 +98,12 @@ class Message extends StatelessWidget {
           )
         ],
       ),
-      margin: new EdgeInsets.symmetric(vertical: 10.0, horizontal: 15.0),
+      margin: new EdgeInsets.symmetric(vertical: 5.0, horizontal: 15.0),
     );
+  }
+
+  get _time {
+
+    return new TimeOfDay(hour: message.date.hour, minute: message.date.minute);
   }
 }

--- a/example/lib/conversation/messageGroup.dart
+++ b/example/lib/conversation/messageGroup.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
+import 'package:sms_example/conversation/message.dart';
+import 'package:sms_example/utils/group.dart';
+
+class MessageGroup extends StatelessWidget {
+
+  final Group group;
+
+  MessageGroup(this.group): super();
+
+  @override
+  Widget build(BuildContext context) {
+    List<Widget> widgets = <Widget>[
+      new Container(
+        child: new Text(MaterialLocalizations.of(context).formatFullDate(group.messages[0].date)),
+        margin: new EdgeInsets.only(top: 10.0),
+      ),
+    ];
+    widgets.addAll(
+        group.messages.map((message) => new Message(message)).toList()
+    );
+
+    return new Container(
+      child: new Column(
+        children: widgets,
+      ),
+    );
+  }
+}

--- a/example/lib/conversation/messages.dart
+++ b/example/lib/conversation/messages.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:sms/sms.dart';
-import 'package:sms_example/conversation/message.dart';
+import 'package:sms_example/conversation/messageGroup.dart';
+import 'package:sms_example/utils/group.dart';
 
 
 class Messages extends StatelessWidget {
@@ -11,8 +12,10 @@ class Messages extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final groups = MessageGroupService.of(context).groupByDate(messages);
+
     return new ListView(
-      children: messages.map((message) => new Message(message)).toList(),
+      children: groups.map((group) => new MessageGroup(group)).toList(),
       reverse: true,
     );
   }

--- a/example/lib/utils/group.dart
+++ b/example/lib/utils/group.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/material.dart';
+import 'package:sms/sms.dart';
+
+class MessageGroupService {
+
+  final BuildContext context;
+
+  static MessageGroupService of(BuildContext context){
+    return new MessageGroupService._private(context);
+  }
+
+  MessageGroupService._private(this.context);
+
+  List<Group> groupByDate(List<SmsMessage> messages) {
+    final groups = new _GroupCollection();
+    messages.forEach((message){
+      String groupLabel = MaterialLocalizations.of(context).formatFullDate(message.date);
+      if (groups.contains(groupLabel)){
+        groups.get(groupLabel).addMessage(message);
+      }
+      else {
+        groups.add(
+            new Group(
+                groupLabel,
+                messages: [message]
+            )
+        );
+      }
+    });
+    return groups.groups;
+  }
+}
+
+class Group {
+  String label;
+  List<SmsMessage> messages;
+
+  Group(this.label, {this.messages = const <SmsMessage>[]});
+
+  void addMessage(SmsMessage message) {
+    messages.insert(0, message);
+  }
+}
+
+class _GroupCollection {
+  List<Group> groups = <Group>[];
+
+  bool contains(String label) {
+    return groups.any((group) {
+      return group.label == label;
+    });
+  }
+
+  Group get(String label) {
+    return groups.singleWhere((group) {
+      return group.label == label;
+    });
+  }
+
+  void add(Group group) {
+    groups.add(group);
+  }
+}


### PR DESCRIPTION
I added some minimal dates information in the example app. But doing that I realize that for a better date handling we should unify 'date' and 'dateSent' fields in SmsMessage class. That's because if we keep them separated the consumer of the package must continuosly check "IF the message was sent then take 'date' field otherwise take 'dateSent' ", etc. This new way users will always have the date of the message in 'date' field, no need to check.

What do you think?